### PR TITLE
Allowing other extensions to depend on Sequences

### DIFF
--- a/MetafileImporter/Logic/CMakeLists.txt
+++ b/MetafileImporter/Logic/CMakeLists.txt
@@ -26,3 +26,6 @@ SlicerMacroBuildModuleLogic(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}Python ${KIT}PythonD FILE "${KIT}Targets.cmake")

--- a/SequenceBrowser/Logic/CMakeLists.txt
+++ b/SequenceBrowser/Logic/CMakeLists.txt
@@ -24,3 +24,6 @@ SlicerMacroBuildModuleLogic(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}Python ${KIT}PythonD FILE "${KIT}Targets.cmake")

--- a/SequenceBrowser/MRML/CMakeLists.txt
+++ b/SequenceBrowser/MRML/CMakeLists.txt
@@ -26,3 +26,6 @@ SlicerMacroBuildModuleMRML(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}Python ${KIT}PythonD FILE "${KIT}Targets.cmake")

--- a/SequenceBrowser/Widgets/CMakeLists.txt
+++ b/SequenceBrowser/Widgets/CMakeLists.txt
@@ -58,3 +58,6 @@ add_subdirectory(DesignerPlugins)
 if(BUILD_TESTING)
   add_subdirectory(Testing)
 endif()
+
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}PythonQt FILE "${KIT}Targets.cmake")

--- a/Sequences/Logic/CMakeLists.txt
+++ b/Sequences/Logic/CMakeLists.txt
@@ -24,3 +24,6 @@ SlicerMacroBuildModuleLogic(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}Python ${KIT}PythonD FILE "${KIT}Targets.cmake")

--- a/Sequences/MRML/CMakeLists.txt
+++ b/Sequences/MRML/CMakeLists.txt
@@ -39,3 +39,6 @@ SlicerMacroBuildModuleMRML(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+  
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}Python ${KIT}PythonD FILE "${KIT}Targets.cmake")

--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -27,6 +27,7 @@
 #include <vtkImageData.h>
 #include <vtkIntArray.h>
 #include <vtkMatrix4x4.h>
+#include <vtkDoubleArray.h>
 #include <vtkMRMLCameraNode.h>
 #include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLModelNode.h>
@@ -38,6 +39,7 @@
 #include <vtkMRMLVectorVolumeDisplayNode.h>
 #include <vtkMRMLViewNode.h>
 #include <vtkMRMLVolumeNode.h>
+#include <vtkMRMLDoubleArrayNode.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkPolyData.h>
@@ -532,6 +534,36 @@ public:
 };
 
 //----------------------------------------------------------------------------
+
+class DoubleArrayNodeSequencer : public vtkMRMLNodeSequencer::NodeSequencer
+{
+public:
+  DoubleArrayNodeSequencer()
+  {
+    this->SupportedNodeClassName = "vtkMRMLDoubleArrayNode";
+    this->SupportedNodeParentClassNames.push_back("vtkMRMLStorableNode");
+    this->SupportedNodeParentClassNames.push_back("vtkMRMLNode");
+  }
+
+  virtual void CopyNode(vtkMRMLNode* source, vtkMRMLNode* target, bool shallowCopy /* =false */)
+  {
+    int oldModified = target->StartModify();
+    vtkMRMLDoubleArrayNode* targetDoubleArrayNode = vtkMRMLDoubleArrayNode::SafeDownCast(target);
+    vtkMRMLDoubleArrayNode* sourceDoubleArrayNode = vtkMRMLDoubleArrayNode::SafeDownCast(source);
+    targetDoubleArrayNode->CopyWithoutModifiedEvent(sourceDoubleArrayNode); // Copies the attributes, etc.
+    vtkDoubleArray* targetDoubleArray = sourceDoubleArrayNode->GetArray();
+    if (!shallowCopy && targetDoubleArray!=NULL)
+    {
+      targetDoubleArray = sourceDoubleArrayNode->GetArray()->NewInstance();
+      targetDoubleArray->DeepCopy(sourceDoubleArrayNode->GetArray());
+    }
+    targetDoubleArrayNode->SetArray(targetDoubleArray);
+    target->EndModify(oldModified);
+  }
+
+};
+
+//----------------------------------------------------------------------------
 // Needed when we don't use the vtkStandardNewMacro.
 vtkInstantiatorNewMacro(vtkMRMLNodeSequencer);
 
@@ -580,6 +612,7 @@ vtkMRMLNodeSequencer::vtkMRMLNodeSequencer():Superclass()
   this->RegisterNodeSequencer(new SliceCompositeNodeSequencer());
   this->RegisterNodeSequencer(new ViewNodeSequencer());
   this->RegisterNodeSequencer(new MarkupsFiducialNodeSequencer());
+  this->RegisterNodeSequencer(new DoubleArrayNodeSequencer());
 }
 
 //----------------------------------------------------------------------------

--- a/Sequences/Widgets/CMakeLists.txt
+++ b/Sequences/Widgets/CMakeLists.txt
@@ -41,3 +41,5 @@ SlicerMacroBuildModuleWidgets(
   WRAP_PYTHONQT
   )
 
+target_include_directories(${KIT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+export(TARGETS ${KIT} ${KIT}PythonQt FILE "${KIT}Targets.cmake")


### PR DESCRIPTION
Exporting targets with properties indicating the include directories. In particular, this will allow the Perk Tutor extension to depend on the Sequences extension. This may later be handled centrally.

This supersedes the pull request #25.