### PR TITLE
Improve performance for reading, writing, and iterating sequences.

### DIFF
--- a/Sequences/MRML/vtkMRMLSequenceNode.h
+++ b/Sequences/MRML/vtkMRMLSequenceNode.h
@@ -114,6 +114,7 @@ public:
   std::string GetNthIndexValue(int itemNumber);
 
   /// If exact match is not required and index is numeric then the best matching data node is returned.
+  /// If the sequences has numeric index, uses data node just before the index value in the case of non-exact match
   int GetItemNumberFromIndexValue(const std::string& indexValue, bool exactMatchRequired = true);
 
   bool UpdateIndexValue(const std::string& oldIndexValue, const std::string& newIndexValue);


### PR DESCRIPTION
Uses binary search to find data nodes corresponding to an index value and insertion position for new nodes to be added to the sequence.

As an example, I had a Sequence of 17000 transforms on my computer. Reading from *.seq.mha file takes 16 seconds now, compared to 85 seconds previously. Iterating through and computing performance metrics on it takes 15 seconds now, compared to 38 seconds previously.