### PR TITLE
BUG: Update data nodes table on Scene close

### DIFF
--- a/Sequences/qSlicerSequencesModuleWidget.cxx
+++ b/Sequences/qSlicerSequencesModuleWidget.cxx
@@ -287,6 +287,7 @@ void qSlicerSequencesModuleWidget::onMRMLSceneEndCloseEvent()
     return;
     }
   this->updateCandidateNodesWidgetFromMRML(true);
+  this->updateSequenceItemWidgetFromMRML();
 } 
 
 //-----------------------------------------------------------------------------
@@ -376,7 +377,7 @@ void qSlicerSequencesModuleWidget::onDataNodeEdited( int row, int column )
     return;
   }
 
-  // Grab the tex from the modified item
+  // Grab the text from the modified item
   QTableWidgetItem* qItem = d->TableWidget_DataNodes->item( row, column );
   QString qText = qItem->text();
 


### PR DESCRIPTION
**Problem:** Data nodes table does not update when scene is closed...

**Active scene:**
![image](https://user-images.githubusercontent.com/22180044/29620306-940b559a-87eb-11e7-802c-4579fc571457.png)

**After scene close** _(before fix)_:
![image](https://user-images.githubusercontent.com/22180044/29620324-a0e2ed1e-87eb-11e7-9efc-9b76f07e8eae.png)

**After scene close** _(after fix)_:
![image](https://user-images.githubusercontent.com/22180044/29620365-bf74eebc-87eb-11e7-8cac-21955a22cb0d.png)
