### PR TITLE
Attempting to fix crashes when manipulating proxy nodes in the scene.

### DIFF
--- a/SequenceBrowser/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/SequenceBrowser/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -649,8 +649,12 @@ vtkMRMLNode* vtkMRMLSequenceBrowserNode::AddProxyNode(vtkMRMLNode* sourceProxyNo
     proxyNode->Delete(); // ownership transferred to the scene, so we can release the pointer
   }
 
-  this->RemoveProxyNode(rolePostfix); // This will also remove the proxy node from the scene if necessary
-  this->SetAndObserveNodeReferenceID(proxyNodeRef.c_str(), proxyNode->GetID(), vtkMRMLNodeSequencer::GetInstance()->GetNodeSequencer(proxyNode)->GetRecordingEvents());
+  vtkMRMLNode* oldProxyNode=this->GetNodeReference(proxyNodeRef.c_str());
+  if (proxyNode!=oldProxyNode)
+  {
+    this->RemoveProxyNode(rolePostfix); // This will also remove the proxy node from the scene if necessary
+    this->SetAndObserveNodeReferenceID(proxyNodeRef.c_str(), proxyNode->GetID(), vtkMRMLNodeSequencer::GetInstance()->GetNodeSequencer(proxyNode)->GetRecordingEvents());
+  }
 
   this->EndModify(oldModify);
   return proxyNode;


### PR DESCRIPTION
This seems to address #32, as well as crashes when manipulating proxy nodes from a reloaded *.mha sequence metafile.