### PR TITLE
Improves sequence loading by enforcing unique names when saving.

### DIFF
--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -119,7 +119,8 @@ vtkMRMLNode* vtkMRMLNodeSequencer::NodeSequencer::DeepCopyNodeToScene(vtkMRMLNod
   vtkSmartPointer<vtkMRMLNode> target = vtkSmartPointer<vtkMRMLNode>::Take(source->CreateNodeInstance());
   this->CopyNode(source, target, false);
 
-  // We will ensure that all file names for storable nodes are unique when saving
+  // Generating unique node names is slow, and makes adding many nodes to a sequence too slow
+  // We will instead ensure that all file names for storable nodes are unique when saving
   target->SetName(newNodeName.c_str());
   target->SetAttribute("Sequences.BaseName", baseName.c_str());
 

--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -114,7 +114,7 @@ vtkMRMLNode* vtkMRMLNodeSequencer::NodeSequencer::DeepCopyNodeToScene(vtkMRMLNod
   {
     baseName = source->GetName();
   }
-  std::string newNodeName = scene->GetUniqueNameByString(baseName.c_str());
+  std::string newNodeName = baseName;
 
   vtkSmartPointer<vtkMRMLNode> target = vtkSmartPointer<vtkMRMLNode>::Take(source->CreateNodeInstance());
   this->CopyNode(source, target, false);

--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -119,8 +119,7 @@ vtkMRMLNode* vtkMRMLNodeSequencer::NodeSequencer::DeepCopyNodeToScene(vtkMRMLNod
   vtkSmartPointer<vtkMRMLNode> target = vtkSmartPointer<vtkMRMLNode>::Take(source->CreateNodeInstance());
   this->CopyNode(source, target, false);
 
-  // Make sure all the node names in the sequence's scene are unique for saving purposes
-  // TODO: it would be better to make sure all names are unique when saving the data?
+  // We will ensure that all file names for storable nodes are unique when saving
   target->SetName(newNodeName.c_str());
   target->SetAttribute("Sequences.BaseName", baseName.c_str());
 

--- a/Sequences/MRML/vtkMRMLSequenceStorageNode.cxx
+++ b/Sequences/MRML/vtkMRMLSequenceStorageNode.cxx
@@ -135,6 +135,7 @@ int vtkMRMLSequenceStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
   bool success = false;
   if (extension == ".mrb")
   {
+    this->ForceUniqueDataNodeFileNames(sequenceNode);
     vtkMRMLScene *sequenceScene=sequenceNode->GetSequenceScene();
     success = WriteToMRB(fullName.c_str(), sequenceScene);
   }
@@ -380,4 +381,33 @@ std::string vtkMRMLSequenceStorageNode::GetSequenceNodeName(const std::string& b
     + NODE_BASE_NAME_SEPARATOR + itemName
     + NODE_BASE_NAME_SEPARATOR + "Seq";
   return fullName;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSequenceStorageNode::ForceUniqueDataNodeFileNames(vtkMRMLSequenceNode* sequenceNode)
+{
+  if (sequenceNode == NULL)
+  {
+    return;
+  }
+
+  for (int i = 0; i < sequenceNode->GetNumberOfDataNodes(); i++)
+  {
+    vtkMRMLStorableNode* currStorableNode = vtkMRMLStorableNode::SafeDownCast(sequenceNode->GetNthDataNode(i));
+    if (currStorableNode==NULL)
+    {
+      continue;
+    }
+    vtkMRMLStorageNode* currStorageNode = currStorableNode->GetStorageNode();
+    if (!currStorageNode)
+    {
+      currStorableNode->AddDefaultStorageNode();
+      currStorageNode = currStorableNode->GetStorageNode();
+    }
+    std::stringstream uniqueFileNameStream;
+    uniqueFileNameStream << currStorableNode->GetName(); // Note that special characters are dealt with by the application logic when writing scene
+    uniqueFileNameStream << "_" << i;
+    std::string uniqueFileName = uniqueFileNameStream.str();
+    currStorageNode->SetFileName(uniqueFileName.c_str());
+  }
 }

--- a/Sequences/MRML/vtkMRMLSequenceStorageNode.cxx
+++ b/Sequences/MRML/vtkMRMLSequenceStorageNode.cxx
@@ -135,7 +135,7 @@ int vtkMRMLSequenceStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
   bool success = false;
   if (extension == ".mrb")
   {
-    this->ForceUniqueDataNodeFileNames(sequenceNode);
+    this->ForceUniqueDataNodeFileNames(sequenceNode); // Prevents storable nodes' files from being overwritten due to the same node name
     vtkMRMLScene *sequenceScene=sequenceNode->GetSequenceScene();
     success = WriteToMRB(fullName.c_str(), sequenceScene);
   }
@@ -406,7 +406,7 @@ void vtkMRMLSequenceStorageNode::ForceUniqueDataNodeFileNames(vtkMRMLSequenceNod
     }
     std::stringstream uniqueFileNameStream;
     uniqueFileNameStream << currStorableNode->GetName(); // Note that special characters are dealt with by the application logic when writing scene
-    uniqueFileNameStream << "_" << i;
+    uniqueFileNameStream << "_" << i; // All file names are suffixed by the item number, ensuring uniqueness
     std::string uniqueFileName = uniqueFileNameStream.str();
     currStorageNode->SetFileName(uniqueFileName.c_str());
   }

--- a/Sequences/MRML/vtkMRMLSequenceStorageNode.h
+++ b/Sequences/MRML/vtkMRMLSequenceStorageNode.h
@@ -20,6 +20,7 @@
 
 #include "vtkSlicerSequencesModuleMRMLExport.h"
 #include "vtkMRMLStorageNode.h"
+#include "vtkMRMLSequenceNode.h"
 
 /// \brief MRML node for model storage on disk.
 ///
@@ -75,6 +76,8 @@ protected:
 
   bool ReadFromMRB(const char* fullName, vtkMRMLScene *scene);
 
+  /// Force each storable node to be saved to a file with a different name, preventing overwriting during saving
+  void ForceUniqueDataNodeFileNames(vtkMRMLSequenceNode* sequenceNode);
 };
 
 #endif


### PR DESCRIPTION
The main advantage of enforcing unique node names in Sequences is to ensure that storable nodes in the sequence are each saved to different file names. Instead of enforcing unique node names when a node is added to the sequence (O(n^2) operation for adding n nodes to the sequence), we now enforce unique file names only at saving time (O(n) operation for saving n nodes). This is significantly faster for loading long sequences, and the difference in saving time is trivial.

I had a 22MB sequence metafile (about 12 minutes long) with 11000 frames each with 6 transforms and no images. On my computer, loading it previously took 63 seconds; loading it now takes 7 seconds. Sequences of this length are quite common in our Perk Tutor experiments.