### PR TITLE
Update vtkSlicerMetafileImporterLogic.cxx

### DIFF
--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
@@ -316,7 +316,7 @@ vtkMRMLSequenceBrowserNode* vtkSlicerMetafileImporterLogic::ReadSequenceMetafile
     frameNumberToIndexValueMap, imageMetaData) == 0)
   {
     // error is logged in ReadTransforms
-    return NULL;
+    vtkWarningMacro("No transforms read from metafile: " << fileName);
   }
 
 #ifdef ENABLE_PERFORMANCE_PROFILING


### PR DESCRIPTION
Enabling loading of sequences with no transforms