### PR TITLE
ENH: Add option to disable module SequencesSampleData

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,18 @@ find_package(Slicer REQUIRED)
 include(${Slicer_USE_FILE})
 
 #-----------------------------------------------------------------------------
-OPTION(SEQUENCES_ENABLE_EXPERIMENTAL_MODULES "Enable the building of work-in-progress, experimental modules." OFF)
+option(SEQUENCES_ENABLE_EXPERIMENTAL_MODULES "Enable the building of work-in-progress, experimental modules." OFF)
+option(SEQUENCES_ENABLE_SAMPLEDATA_MODULE "Enable module SequenceSampleData, it depends on the Slicer module SampleData." ON)
+mark_as_advanced(SEQUENCES_ENABLE_SAMPLEDATA_MODULE)
+
 
 #-----------------------------------------------------------------------------
 add_subdirectory(Sequences)
 add_subdirectory(SequenceBrowser)
 add_subdirectory(MetafileImporter)
-add_subdirectory(SequenceSampleData)
+if (SEQUENCES_ENABLE_SAMPLEDATA_MODULE)
+  add_subdirectory(SequenceSampleData)
+endif()
 add_subdirectory(CropVolumeSequence)
 
 if (SEQUENCES_ENABLE_EXPERIMENTAL_MODULES)


### PR DESCRIPTION
The motivation is to use Sequences in a custom Slicer where
the Slicer-proper module SampleData is disabled.

The python module SequencesSampleData depends on SampleData.
I was receiving this warning when launching the custom Slicer:

```
Traceback (most recent call last):
  File
  "/home/user/Software/Shape/SALT/buildRelWithDebInfo/Slicer-build/lib/SlicerSALT-4.9/qt-scripted-modules/SequenceSampleData.py",
  line 33, in __init__
      import SampleData
      ImportError: No module named SampleData
      qSlicerPythonCppAPI::instantiateClass  - [ "SequenceSampleData" ]
      - Failed to instantiate scripted pythonqt class
      "SequenceSampleData" 0x7f4c51d834c8
      Fail to instantiate module  "SequenceSampleData"
```

This disables that warning not building SequenceSampleData when
SampleData is not enabled in Slicer.

Originated: https://github.com/Kitware/SlicerSALT/issues/50