### PR TITLE
COMP: Fix build updating VTK version check

### DIFF
--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -587,7 +587,7 @@ public:
 };
 
 //----------------------------------------------------------------------------
-#if VTK_MAJOR_VERSION < 9
+#if VTK_MAJOR_VERSION <= 7 || (VTK_MAJOR_VERSION <= 8 && VTK_MINOR_VERSION <= 1)
   // Needed when we don't use the vtkStandardNewMacro.
   vtkInstantiatorNewMacro(vtkMRMLNodeSequencer);
 #endif


### PR DESCRIPTION
See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/Slicer#Slicer_4.9:_Update_of_VTK_version_from_9.0_to_8.2

This fixes build errors reported on CDash: http://slicer.cdash.org/viewBuildError.php?buildid=1399457