### PR TITLE
BUG: Fix memory leaks after loading transform from sequence

### DIFF
--- a/Sequences/MRML/vtkMRMLLinearTransformSequenceStorageNode.cxx
+++ b/Sequences/MRML/vtkMRMLLinearTransformSequenceStorageNode.cxx
@@ -268,7 +268,7 @@ int vtkMRMLLinearTransformSequenceStorageNode::ReadSequenceFileTransforms(const 
       if (transformSequenceNodes.find(transform->GetName()) == transformSequenceNodes.end())
       {
         // Setup hierarchy structure
-        vtkMRMLSequenceNode* newTransformsSequenceNode = NULL;
+        vtkSmartPointer<vtkMRMLSequenceNode> newTransformsSequenceNode;
         if (numberOfCreatedNodes < static_cast<int>(createdNodes.size()))
         {
           // reuse supplied sequence node
@@ -278,7 +278,7 @@ int vtkMRMLLinearTransformSequenceStorageNode::ReadSequenceFileTransforms(const 
         else
         {
           // Create new sequence node
-          newTransformsSequenceNode = vtkMRMLSequenceNode::New();
+          newTransformsSequenceNode = vtkSmartPointer<vtkMRMLSequenceNode>::New();
           createdNodes.push_back(newTransformsSequenceNode);
         }
         numberOfCreatedNodes++;


### PR DESCRIPTION
This closes #69.

Let me know if this is the correct fix or suggestions for other methods here!

Now after loading a sequence metafile with transform sequences and then closing Slicer:
`vtkDebugLeaks has found no leaks.`