### PR TITLE
BUG: qSlicerSequencesModuleWidget: Remove obsolete connection to onHideDataNodeClicked

### DIFF
--- a/Sequences/qSlicerSequencesModuleWidget.cxx
+++ b/Sequences/qSlicerSequencesModuleWidget.cxx
@@ -181,7 +181,6 @@ void qSlicerSequencesModuleWidget::setup()
 
   //connect( d->TableWidget_DataNodes, SIGNAL( currentCellChanged( int, int, int, int ) ), this, SLOT( onDataNodeChanged() ) );
   connect( d->TableWidget_DataNodes, SIGNAL( cellChanged( int, int ) ), this, SLOT( onDataNodeEdited( int, int ) ) );
-  connect( d->TableWidget_DataNodes, SIGNAL( cellClicked( int, int ) ), this, SLOT( onHideDataNodeClicked( int, int ) ) );
 
   connect( d->PushButton_AddDataNode, SIGNAL( clicked() ), this, SLOT( onAddDataNodeButtonClicked() ) );
   d->PushButton_AddDataNode->setIcon( QApplication::style()->standardIcon( QStyle::SP_ArrowLeft ) );


### PR DESCRIPTION
This slot was removed in bccf3d072 (Improved automatic proxy node renaming)

This commit fixes the following runtime error:

```
  QObject::connect: No such slot qSlicerSequencesModuleWidget::onHideDataNodeClicked( int, int ) in /tmp/Sequences/Sequences/qSlicerSequencesModuleWidget.cxx:184
  QObject::connect:  (sender name:   'TableWidget_DataNodes')
  QObject::connect:  (receiver name: 'SequencesModuleWidget')
```