### PR TITLE
BUG: Fix recording of markups fiducial updates

### DIFF
--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -465,14 +465,13 @@ public:
 
 //----------------------------------------------------------------------------
 
-class MarkupsFiducialNodeSequencer : public vtkMRMLNodeSequencer::NodeSequencer
+class MarkupsNodeSequencer : public vtkMRMLNodeSequencer::NodeSequencer
 {
 public:
-  MarkupsFiducialNodeSequencer()
+  MarkupsNodeSequencer()
   {
-    this->RecordingEvents->InsertNextValue(vtkMRMLMarkupsFiducialNode::PointModifiedEvent);
-    this->SupportedNodeClassName = "vtkMRMLMarkupsFiducialNode";
-    this->SupportedNodeParentClassNames.push_back("vtkMRMLMarkupsNode");
+    this->RecordingEvents->InsertNextValue(vtkMRMLMarkupsNode::PointModifiedEvent);
+    this->SupportedNodeClassName = "vtkMRMLMarkupsNode";
     this->SupportedNodeParentClassNames.push_back("vtkMRMLDisplayableNode");
     this->SupportedNodeParentClassNames.push_back("vtkMRMLTransformableNode");
     this->SupportedNodeParentClassNames.push_back("vtkMRMLStorableNode");
@@ -484,9 +483,9 @@ public:
     // Don't copy with single-modified-event
     // TODO: check if default behavior is really not correct
     int oldModified = target->StartModify();
-    vtkMRMLMarkupsFiducialNode* targetMarkupsFiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(target);
-    vtkMRMLMarkupsFiducialNode* sourceMarkupsFiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(source);
-    targetMarkupsFiducialNode->Copy(sourceMarkupsFiducialNode);
+    vtkMRMLMarkupsNode* targetMarkupsNode = vtkMRMLMarkupsNode::SafeDownCast(target);
+    vtkMRMLMarkupsNode* sourceMarkupsNode = vtkMRMLMarkupsNode::SafeDownCast(source);
+    targetMarkupsNode->Copy(sourceMarkupsNode);
     target->EndModify(oldModified);
   }
 
@@ -677,7 +676,7 @@ vtkMRMLNodeSequencer::vtkMRMLNodeSequencer():Superclass()
   this->RegisterNodeSequencer(new SliceNodeSequencer());
   this->RegisterNodeSequencer(new SliceCompositeNodeSequencer());
   this->RegisterNodeSequencer(new ViewNodeSequencer());
-  this->RegisterNodeSequencer(new MarkupsFiducialNodeSequencer());
+  this->RegisterNodeSequencer(new MarkupsNodeSequencer());
   this->RegisterNodeSequencer(new DoubleArrayNodeSequencer());
 }
 

--- a/Sequences/MRML/vtkMRMLNodeSequencer.cxx
+++ b/Sequences/MRML/vtkMRMLNodeSequencer.cxx
@@ -470,8 +470,7 @@ class MarkupsFiducialNodeSequencer : public vtkMRMLNodeSequencer::NodeSequencer
 public:
   MarkupsFiducialNodeSequencer()
   {
-    // TODO: check if a special event is needed
-    //this->RecordingEvents->InsertNextValue(vtkMRMLModelNode::PolyDataModifiedEvent);
+    this->RecordingEvents->InsertNextValue(vtkMRMLMarkupsFiducialNode::PointModifiedEvent);
     this->SupportedNodeClassName = "vtkMRMLMarkupsFiducialNode";
     this->SupportedNodeParentClassNames.push_back("vtkMRMLMarkupsNode");
     this->SupportedNodeParentClassNames.push_back("vtkMRMLDisplayableNode");


### PR DESCRIPTION
This commit updates MarkupsFiducialNodeSequencer to account for
changed introduced in Sliced r27974 (ENH: Reworked markups fiducials
and added line, angle, and curves)

Suggested-by: Andras Lasso <lasso@queensu.ca>