### PR TITLE
COMP: Fix windows link error adding dependency to VolumeRendering MRML library

### DIFF
--- a/Sequences/MRML/CMakeLists.txt
+++ b/Sequences/MRML/CMakeLists.txt
@@ -29,6 +29,7 @@ set(${KIT}_TARGET_LIBRARIES
   SlicerBaseLogic
   qSlicerBaseQTCLI
   vtkSlicerMarkupsModuleMRML
+  vtkSlicerVolumeRenderingModuleMRML
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes a regression introduced in previous commit. It fixes
the following error:

```
  vtkMRMLNodeSequencer.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static class vtkMRMLVolumePropertyNode  [...]
```

Reported-by: Tamas Ungi <ungi@queensu.ca>