### PR TITLE
COMP: fix override warnings and one logic issue

### DIFF
--- a/MetafileImporter/qSlicerMetafileImporterModule.h
+++ b/MetafileImporter/qSlicerMetafileImporterModule.h
@@ -49,28 +49,28 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText()const override;
+  virtual QString acknowledgementText()const override;
+  virtual QStringList contributors()const override;
 
-  virtual QIcon icon()const;
+  virtual QIcon icon()const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories()const override;
+  virtual QStringList dependencies() const override;
 
   /// Make this module hidden
-  virtual bool isHidden()const { return true; };
+  virtual bool isHidden()const override { return true; };
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerMetafileImporterModulePrivate> d_ptr;

--- a/SequenceBrowser/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
+++ b/SequenceBrowser/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
@@ -179,7 +179,7 @@ void qMRMLSequenceBrowserSeekWidget::updateWidgetFromMRML()
     d->label_IndexValue->setText(indexValue);
     d->label_IndexUnit->setText(indexUnit);
 
-    if (!indexValue.length() == 0)
+    if (indexValue.length() != 0)
     {
       d->label_IndexValue->setFixedWidth(std::max(fontMetrics.width(indexValue), d->label_IndexValue->width()));
     }

--- a/SequenceBrowser/qSlicerSequenceBrowserModule.h
+++ b/SequenceBrowser/qSlicerSequenceBrowserModule.h
@@ -58,14 +58,14 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText()const override;
+  virtual QString acknowledgementText()const override;
+  virtual QStringList contributors()const override;
 
-  virtual QIcon icon()const;
+  virtual QIcon icon()const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories()const override;
+  virtual QStringList dependencies() const override;
 
   /// Indicates that sequence browser toolbar should be showed when a new sequence is loaded.
   /// Adding a new sequence browser node to the scene does not show the toolbar automatically
@@ -81,16 +81,16 @@ public:
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 public slots:
-  virtual void setMRMLScene(vtkMRMLScene*);
+  virtual void setMRMLScene(vtkMRMLScene*) override;
   void setToolBarVisible(bool visible);
   /// Enables automatic showing sequence browser toolbar when a new sequence is loaded
   void setAutoShowToolBar(bool autoShow);

--- a/Sequences/qSlicerSequencesModule.h
+++ b/Sequences/qSlicerSequencesModule.h
@@ -46,25 +46,25 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText()const override;
+  virtual QString acknowledgementText()const override;
+  virtual QStringList contributors()const override;
 
-  virtual QIcon icon()const;
+  virtual QIcon icon()const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories()const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerSequencesModulePrivate> d_ptr;


### PR DESCRIPTION
Adds override keyword where needed.

Fixes an issue with a misplaced `!` (not)
operator in an if statement.

@lassoan - please doublecheck the logic in `qMRMLSequenceBrowserSeekWidget.cxx` to be sure this fix matches what was intended.