### PR TITLE
ENH: Reset width of index value label when IndexDisplayFormat is changed

### DIFF
--- a/SequenceBrowser/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/SequenceBrowser/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -1425,6 +1425,18 @@ int vtkMRMLSequenceBrowserNode::GetRecordingSamplingModeFromString(const std::st
 }
 
 //-----------------------------------------------------------
+void vtkMRMLSequenceBrowserNode::SetIndexDisplayFormat(std::string indexDisplayNode)
+{
+  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting IndexDisplayFormat to " << indexDisplayNode);
+  if (this->IndexDisplayFormat != indexDisplayNode)
+  {
+    this->IndexDisplayFormat = indexDisplayNode;
+    this->InvokeCustomModifiedEvent(IndexDisplayFormatModifiedEvent);
+    this->Modified();
+  }
+}
+
+//-----------------------------------------------------------
 void vtkMRMLSequenceBrowserNode::SetIndexDisplayModeFromString(const char *indexDisplayModeString)
 {
   int indexDisplayMode = GetIndexDisplayModeFromString(indexDisplayModeString);

--- a/SequenceBrowser/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/SequenceBrowser/MRML/vtkMRMLSequenceBrowserNode.h
@@ -47,7 +47,8 @@ public:
   /// ProxyNodeModifiedEvent is invoked when a proxy node is modified
   enum
   {
-    ProxyNodeModifiedEvent = 21001
+    ProxyNodeModifiedEvent = 21001,
+    IndexDisplayFormatModifiedEvent
   };
 
   /// Modes for determining recording frame rate.
@@ -170,7 +171,7 @@ public:
   virtual std::string GetIndexDisplayModeAsString();
 
   /// Set format of index value display
-  vtkSetMacro(IndexDisplayFormat, std::string);
+  void SetIndexDisplayFormat(std::string displayFormat);
   /// Get format of index value display
   vtkGetMacro(IndexDisplayFormat, std::string);
 

--- a/SequenceBrowser/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
+++ b/SequenceBrowser/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
@@ -89,11 +89,13 @@ void qMRMLSequenceBrowserSeekWidget::setMRMLSequenceBrowserNode(vtkMRMLSequenceB
 {
   Q_D(qMRMLSequenceBrowserSeekWidget);
 
+  qvtkReconnect(d->SequenceBrowserNode, browserNode, vtkMRMLSequenceBrowserNode::IndexDisplayFormatModifiedEvent,
+    this, SLOT(onIndexDisplayFormatModified()));
   qvtkReconnect(d->SequenceBrowserNode, browserNode, vtkCommand::ModifiedEvent,
     this, SLOT(updateWidgetFromMRML()));
 
   d->SequenceBrowserNode = browserNode;
-  d->label_IndexValue->setFixedWidth(0); // Reset fixed width of index value label
+  this->onIndexDisplayFormatModified();
   this->updateWidgetFromMRML();
 }
 
@@ -117,6 +119,15 @@ void qMRMLSequenceBrowserSeekWidget::setSelectedItemNumber(int itemNumber)
     }
   }
   d->SequenceBrowserNode->SetSelectedItemNumber(selectedItemNumber);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceBrowserSeekWidget::onIndexDisplayFormatModified()
+{
+  Q_D(qMRMLSequenceBrowserSeekWidget);
+  // Reset the fixed width of the label
+  QFontMetrics fontMetrics = QFontMetrics(d->label_IndexValue->font());
+  d->label_IndexValue->setFixedWidth(fontMetrics.width(d->label_IndexValue->text()));
 }
 
 //-----------------------------------------------------------------------------
@@ -179,14 +190,7 @@ void qMRMLSequenceBrowserSeekWidget::updateWidgetFromMRML()
     d->label_IndexValue->setText(indexValue);
     d->label_IndexUnit->setText(indexUnit);
 
-    if (indexValue.length() != 0)
-    {
-      d->label_IndexValue->setFixedWidth(std::max(fontMetrics.width(indexValue), d->label_IndexValue->width()));
-    }
-    else
-    {
-      d->label_IndexValue->setFixedWidth(0);
-    }
+    d->label_IndexValue->setFixedWidth(std::max(fontMetrics.width(indexValue), d->label_IndexValue->width()));
     d->slider_IndexValue->setValue(selectedItemNumber);
   }
   else

--- a/SequenceBrowser/Widgets/qMRMLSequenceBrowserSeekWidget.h
+++ b/SequenceBrowser/Widgets/qMRMLSequenceBrowserSeekWidget.h
@@ -54,6 +54,7 @@ public slots:
   void setSelectedItemNumber(int itemNumber);
 
 protected slots:
+  void onIndexDisplayFormatModified();
   void updateWidgetFromMRML();
 
 protected:


### PR DESCRIPTION
Updates the fixed width of the index value label to the correct size when the sequence browser IndexDisplayFormat is changed.
This uses the same process as updateWidgetFromMRML, however the width is allowed to shrink in onIndexDisplayFormatModified().